### PR TITLE
read method should accept optional outbuf to conform to IO interface …

### DIFF
--- a/lib/client.rb
+++ b/lib/client.rb
@@ -41,8 +41,12 @@ module SoftLayer
         @file = data
       end
       
-      def read(foo)
-        @file.read(@size)
+      def read(foo, out = nil)
+        if out && out.respond_to?("write")
+          out.write @file.read(@size)
+        else
+          @file.read(@size)
+        end
       end
 
       def eof!


### PR DESCRIPTION
While trying to pass an IO object to the storage_object.write method, I got the error: softlayer-object-storage-0.0.1/lib/client.rb:44:in `read': wrong number of arguments (given 2, expected 1) (ArgumentError). This patch allowed me to pass an IO object to eh storage_object for writing.