### PR TITLE
Accept optional output_buffer for read method of object_storage object

### DIFF
--- a/lib/client.rb
+++ b/lib/client.rb
@@ -43,7 +43,7 @@ module SoftLayer
       
       def read(foo, out = nil)
         if out && out.respond_to?("write")
-          out.write @file.read(@size)
+          @file.read(@size, out)
         else
           @file.read(@size)
         end

--- a/lib/client.rb
+++ b/lib/client.rb
@@ -41,8 +41,12 @@ module SoftLayer
         @file = data
       end
       
-      def read(foo)
-        @file.read(@size)
+      def read(foo, out = nil)
+        if out && out.respond_to?("write")
+          out.write @file.read(@size)
+        else
+          @file.read(@size)
+        end
       end
 
       def eof!


### PR DESCRIPTION
object_storage should conform to the interface for IO, which means having a read method which optionally specifies an output buffer for the data being read, instead of the object returning the data.